### PR TITLE
Don't use `Buffer ? Buffer.foo : bar` to avoid a ReferenceError

### DIFF
--- a/src/protobuf-client.ts
+++ b/src/protobuf-client.ts
@@ -38,7 +38,12 @@ class TwirpProtobufClient {
     return this.axiosClient
       .post(`/${service}/${method}`, data)
       .then((response: AxiosResponse<Buffer>) => {
-        return Buffer ? Buffer.from(response.data) : new Uint8Array(response.data);
+        try {
+          Buffer;
+        } catch(e) {
+          return new Uint8Array(response.data);
+        }
+        return Buffer.from(response.data);
       })
       .catch((error: AxiosError) => {
         if (error.response != undefined) {


### PR DESCRIPTION
Use a try-catch to check whether Buffer exists instead.

closes #2